### PR TITLE
日時計算時に切り捨てが行われる問題を修正

### DIFF
--- a/content.ts
+++ b/content.ts
@@ -85,7 +85,7 @@ const colorizeManaba = () => {
 
     const now = dayjs()
 
-    const diffDays = deadline.diff(now, "days")
+    const diffDays = deadline.diff(now, "days", true)
     row.classList.add(classNameFromDiffDays(diffDays))
 
     const daysLeftColumn = document.createElement("td")


### PR DESCRIPTION
## 概要
dayjsの`diff`メソッドは第3引数を渡さない場合、日時の差分を計算する際に時間以下を切り捨てます。  
一方、(直感的には | manaba-enhancedの挙動では) 時間以下についても考慮して色付く方が良いので修正しました。

### 修正前
<img width="686" alt="スクリーンショット 2023-10-10 23 53 44" src="https://github.com/s7tya/iroduku-manaba/assets/43488453/0b7ab623-0996-4a19-ac6d-7e86d4a336b8">

### 修正後
<img width="679" alt="スクリーンショット 2023-10-10 23 56 45" src="https://github.com/s7tya/iroduku-manaba/assets/43488453/22bae886-ef70-46b8-868e-1ea18ede198c">

※ 撮影日時: 2023.10.10 23:56

### 参考
https://day.js.org/docs/en/display/difference